### PR TITLE
Fix Pleroma and Akkoma Actor Relay

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -45,3 +45,11 @@
 # Ignore Docker-related files
 /.dockerignore
 /Dockerfile*
+
+# Ignore coverage
+/coverage
+
+# Ignore Vim swap file
+*.swp
+*.swo
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,9 +48,6 @@ RUN bundle exec bootsnap precompile app/ lib/
 # Precompiling assets for production without requiring secret RAILS_MASTER_KEY
 RUN SECRET_KEY_BASE_DUMMY=1 ./bin/rails assets:precompile
 
-RUN SECRET_KEY_BASE_DUMMY=1 ./bin/rails relay:keygen
-
-
 # Final stage for app image
 FROM base
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # ActivityPub Relay
 
 Mastodon and Misskey(or other Misskey fork) supported ActivityPub Relay.
+Also Actor Relay that support Pleroma and Akkoma.
 
 ## References
 

--- a/app/views/root/index.html.erb
+++ b/app/views/root/index.html.erb
@@ -34,6 +34,15 @@
           </div>
         </div>
       </div>
+      <div>
+        <h2 class="text-3xl">PleromaとAkkoma の場合</h2>
+        <div class="flex flex-col gap-3">
+          <span class="text-2xl">以下のactor urlをメニューのCLIから追加してください。</span>
+          <div class="border-solid border-2 border-slate-950 p-4">
+            <%= "https://#{ENV["LOCAL_DOMAIN"]}/actor" %>
+          </div>
+        </div>
+      </div>
     </div>
   </div>
   <div class="flex flex-col gap-3">

--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -87,6 +87,7 @@ asset_path: /rails/public/assets
 # Configure the image builder.
 builder:
   arch: amd64
+  context: .
 
   # # Build image via remote server (useful for faster amd64 builds on arm64 computers)
   # remote: ssh://docker@docker-builder-server

--- a/docs/english/deploy/index.md
+++ b/docs/english/deploy/index.md
@@ -22,6 +22,14 @@ Create credentials for Kamal, and copy `secret_key_base` value.
 EDITOR=<Your Editor> bin/rails credentials:edit
 ```
 
+### Generate Actor Key
+
+ActivityPub Relay need Actor Key for Actor Relay that support Pleroma and Akkoma.
+
+```console
+bin/rails relay:keygen 
+```
+
 ### Generate SSH Key
 
 ActivityPub Relay need SSH Key for deploy to server.

--- a/docs/english/index.md
+++ b/docs/english/index.md
@@ -1,6 +1,7 @@
 # ActivityPub Relay
 
 Mastodon and Misskey(or other Misskey fork) supported ActivityPub Relay.
+Also Actor Relay that support Pleroma and Akkoma.
 
 ## References
 

--- a/docs/japanese/deploy/index.md
+++ b/docs/japanese/deploy/index.md
@@ -23,6 +23,14 @@ Kamalで利用するcredentialを作成し、`secret_key_base` の値をコピ�
 EDITOR=<Your Editor> bin/rails credentials:edit
 ```
 
+### Actorリレー用のキーを生成
+
+PleromaやAkkoma向けのActorリレーで必要なキーを生成します。
+
+```console
+bin/rails relay:keygen 
+```
+
 ### SSHキーの生成
 
 ActivityPub Relay はサーバへのデプロイにSSHキーが必要です。

--- a/docs/japanese/index.md
+++ b/docs/japanese/index.md
@@ -1,6 +1,7 @@
 # ActivityPub Relay
 
 Mastodon と Misskey(またはMisskeyフォーク) に対応したActivityPubリレーサーバです。
+またPleromaとAkkomaで利用できるActorリレーにも対応しています。
 
 ## 参考実装
 


### PR DESCRIPTION
## Motivation or Background

For supported Actor Relay(for Pleroma and Akkoma).

## Detail

ActivityPub Relay already supported Actor Relay(for Pleroma and Akkoma).
But, ActivityPub Relay updated actor.pem when deploy.
So, each deploy updated actor.pem and that caused fail to activity delivery from Pleroma and Akkoma.

Fix deploy flow and comletly support to Actor Relay(for Pleroma and Akkoma).

## Checklist
- [x] Passed Test
- [x] Migration Rollback
- [x] Need to write this change in relase notes?

## Context

For completly support to Actor Relay.
