### PR TITLE
Let the development container move even when using M1,M2 Mac

### DIFF
--- a/.devcontainer/compose.yml
+++ b/.devcontainer/compose.yml
@@ -6,6 +6,7 @@ services:
       dockerfile: .devcontainer/Dockerfile
     volumes:
       - ..:/workspaces/activity-pub-relay:cached
+    platform: linux/x86_64
     environment:
       RAILS_ENV: development
       BINDING: 0.0.0.0


### PR DESCRIPTION
## Motivation or Background

Could not deploy the dev container using MacBook Air(M2), and fixed it.

## Detail

Adding the following line above `environment`
> platform: linux/x86_64

## Checklist
- [x] Passed Test
- [x] Migration Rollback
- [x] Need to write this change in relase notes?

## Context

Write link for issue
