### PR TITLE
Fix /.well-know/webfinger endpoint specific

### DIFF
--- a/app/controllers/webfinger_controller.rb
+++ b/app/controllers/webfinger_controller.rb
@@ -1,4 +1,6 @@
 class WebfingerController < ApiController
+  before_action :check_acct
+
   def show
     render json: {
       subject: "acct:relay@#{ENV.fetch("LOCAL_DOMAIN", "www.example.com")}",
@@ -10,5 +12,13 @@ class WebfingerController < ApiController
         }
       ]
     }, content_type: "application/activity+json"
+  end
+
+  private
+
+  def check_acct
+    if params[:resource].blank? || params[:resource] != "acct:relay@#{ENV.fetch("LOCAL_DOMAIN", "www.example.com")}"
+      head :not_found
+    end
   end
 end

--- a/spec/requests/webfinger_controller_spec.rb
+++ b/spec/requests/webfinger_controller_spec.rb
@@ -5,33 +5,57 @@ RSpec.describe "/.well-known/webfinger", type: :request do
     before do
       allow(ENV).to receive(:fetch).and_call_original
       allow(ENV).to receive(:fetch).with("LOCAL_DOMAIN", "www.example.com").and_return("www.example.com")
-
-      get "/.well-known/webfinger"
     end
 
-    it "should return json" do
-      expect(response.content_type).to eq 'application/activity+json; charset=utf-8'
+    context "when params[:resource] is blank" do
+      before do
+        get "/.well-known/webfinger"
+      end
+
+      it "should return 404" do
+        expect(response.status).to eq 404
+      end
     end
 
-    it "should return 200" do
-      expect(response.status).to eq 200
+    context "when params[:resource] is wrong" do
+      before do
+        get "/.well-known/webfinger?resource=acct:wrong@www.example.com"
+      end
+
+      it "should return 404" do
+        expect(response.status).to eq 404
+      end
     end
 
-    it "has actor data" do
-      expected_json = {
-        "subject" => "acct:relay@www.example.com",
-        "links" => [
-          {
-            "rel" =>  "self",
-            "type" => "application/activity+json",
-            "href" => "https://www.example.com/actor"
-          }
-        ]
-      }
+    context "when params[:resource] is present" do
+      before do
+        get "/.well-known/webfinger?resource=acct:relay@www.example.com"
+      end
 
-      actuacl_json = JSON.parse(response.body)
+      it "should return json" do
+        expect(response.content_type).to eq 'application/activity+json; charset=utf-8'
+      end
 
-      expect(expected_json).to eq actuacl_json
+      it "should return 200" do
+        expect(response.status).to eq 200
+      end
+
+      it "has actor data" do
+        expected_json = {
+          "subject" => "acct:relay@www.example.com",
+          "links" => [
+            {
+              "rel" =>  "self",
+              "type" => "application/activity+json",
+              "href" => "https://www.example.com/actor"
+            }
+          ]
+        }
+
+        actuacl_json = JSON.parse(response.body)
+
+        expect(expected_json).to eq actuacl_json
+      end
     end
   end
 end


### PR DESCRIPTION
## Motivation or Background

Add check to params[:resource] is correct acct.

## Detail

Ditto.

## Checklist
- [x] Passed Test
- [x] Migration Rollback
- [x] Need to write this change in relase notes?

## Context

None