### PR TITLE
Fix bin/dev command

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,2 +1,3 @@
 web: bin/rails server
+job: bin/jobs start
 css: bin/rails tailwindcss:watch


### PR DESCRIPTION
## Motivation or Background

When use bin/dev command for check behavior, job server wasn't work.
So, add bin/job start to `Procfile.dev` and job server was running.


## Detail

Ditto.

## Checklist
- [x] Passed Test
- [x] Migration Rollback
- [ ] Need to write this change in relase notes?

## Context

None.