### PR TITLE
Drop support to Pleroma and Akkoma Relay

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # ActivityPub Relay
 
 Mastodon and Misskey(or other Misskey fork) supported ActivityPub Relay.
-Also Actor Relay that support Pleroma and Akkoma.
 
 ## References
 

--- a/app/views/root/index.html.erb
+++ b/app/views/root/index.html.erb
@@ -34,15 +34,6 @@
           </div>
         </div>
       </div>
-      <div>
-        <h2 class="text-3xl">PleromaとAkkoma の場合</h2>
-        <div class="flex flex-col gap-3">
-          <span class="text-2xl">以下のactor urlをメニューのCLIから追加してください。</span>
-          <div class="border-solid border-2 border-slate-950 p-4">
-            <%= "https://#{ENV["LOCAL_DOMAIN"]}/actor" %>
-          </div>
-        </div>
-      </div>
     </div>
   </div>
   <div class="flex flex-col gap-3">

--- a/docs/english/deploy/index.md
+++ b/docs/english/deploy/index.md
@@ -24,7 +24,7 @@ EDITOR=<Your Editor> bin/rails credentials:edit
 
 ### Generate Actor Key
 
-ActivityPub Relay need Actor Key for Actor Relay that support Pleroma and Akkoma.
+ActivityPub Relay need Actor Key for Actor Relay.
 
 ```console
 bin/rails relay:keygen 

--- a/docs/english/index.md
+++ b/docs/english/index.md
@@ -1,7 +1,6 @@
 # ActivityPub Relay
 
 Mastodon and Misskey(or other Misskey fork) supported ActivityPub Relay.
-Also Actor Relay that support Pleroma and Akkoma.
 
 ## References
 

--- a/docs/japanese/deploy/index.md
+++ b/docs/japanese/deploy/index.md
@@ -23,9 +23,9 @@ Kamalで利用するcredentialを作成し、`secret_key_base` の値をコピ�
 EDITOR=<Your Editor> bin/rails credentials:edit
 ```
 
-### Actorリレー用のキーを生成
+### Actorキーを生成
 
-PleromaやAkkoma向けのActorリレーで必要なキーを生成します。
+リレーで必要なActorキーを生成します。
 
 ```console
 bin/rails relay:keygen 

--- a/docs/japanese/index.md
+++ b/docs/japanese/index.md
@@ -1,7 +1,6 @@
 # ActivityPub Relay
 
 Mastodon と Misskey(またはMisskeyフォーク) に対応したActivityPubリレーサーバです。
-またPleromaとAkkomaで利用できるActorリレーにも対応しています。
 
 ## 参考実装
 


### PR DESCRIPTION
## Motivation or Background

Drop support to Pleroma and Akkoma Relay

## Detail

Need more implimentation to support Pleroma and Akkoma Relay.
But, currently the costs for this are not affordable.
So, I decide to drop supoort to Pleroma and Akkoma.

## Checklist
- [x] Passed Test
- [x] Migration Rollback
- [x] Need to write this change in relase notes?

## Context

None.