### PR TITLE
Fix Pleroma and Akkoma relay folow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # ActivityPub Relay
 
 Mastodon and Misskey(or other Misskey fork) supported ActivityPub Relay.
+Also support Pleroma and Akkoma.
 
 ## References
 

--- a/app/controllers/actors_controller.rb
+++ b/app/controllers/actors_controller.rb
@@ -6,6 +6,7 @@ class ActorsController < ApiController
       type: "Service",
       preferredUsername: "relay",
       inbox: "https://#{ENV.fetch("LOCAL_DOMAIN", "www.example.com")}/inbox",
+      url: "https://#{ENV.fetch("LOCAL_DOMAIN", "www.example.com")}/actor",
       publicKey: {
         id: "https://#{ENV.fetch("LOCAL_DOMAIN", "www.example.com")}/actor#main-key",
         owner: "https://#{ENV.fetch("LOCAL_DOMAIN", "www.example.com")}/actor",

--- a/app/models/activity_pub_type_handler.rb
+++ b/app/models/activity_pub_type_handler.rb
@@ -1,7 +1,8 @@
 class ActivityPubTypeHandler
   PUBLIC_COLLECTION = "https://www.w3.org/ns/activitystreams#Public"
 
-  def initialize(json)
+  def initialize(actor, json)
+    @actor = actor
     @json = json
   end
 
@@ -11,6 +12,8 @@ class ActivityPubTypeHandler
     elsif unfollow?
       :unfollow
     elsif valid_for_rebroadcast?
+      :valid_for_rebroadcast
+    elsif pleroma_relay_announce?
       :valid_for_rebroadcast
     else
       :none
@@ -59,5 +62,9 @@ class ActivityPubTypeHandler
     else
       false
     end
+  end
+
+  def pleroma_relay_announce?
+    @actor["preferredUsername"] == "relay" && @json["type"] == "Announce"
   end
 end

--- a/app/models/inbox_process_handler.rb
+++ b/app/models/inbox_process_handler.rb
@@ -1,6 +1,6 @@
 class InboxProcessHandler
   def call(actor, json)
-    activity_pub_type = ActivityPubTypeHandler.new(json).call
+    activity_pub_type = ActivityPubTypeHandler.new(actor, json).call
 
     case activity_pub_type
     when :follow

--- a/app/models/mastodon_follow_handler.rb
+++ b/app/models/mastodon_follow_handler.rb
@@ -1,0 +1,38 @@
+class MastodonFollowHandler
+  def initialize(actor, json)
+    @actor = actor
+    @json = json
+  end
+
+  def call
+    inbox_url = @actor["endpoints"].is_a?(Hash) && @actor["endpoints"]["sharedInbox"].present? ? @actor["endpoints"]["sharedInbox"] : @actor["inbox"]
+
+    domain = URI.parse(@actor["id"]).normalize.host
+
+    accept_activity = {
+      "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://w3id.org/security/v1"
+      ],
+      id: URI.join("https://#{ENV['LOCAL_DOMAIN']}/actor#accepts/follows/#{URI.parse(@actor['id']).normalize.host}"),
+      type: "Accept",
+      actor: "https://#{ENV['LOCAL_DOMAIN']}/actor",
+        object: {
+          id: @json["id"],
+          type: "Follow",
+          actor: @actor["id"],
+          object: "https://#{ENV['LOCAL_DOMAIN']}/actor"
+        }
+    }.to_json
+
+    response = ActivityPubDeliveryClient.new(inbox_url, accept_activity).send
+
+    if response.code == "202"
+      SubscribeServer.create!(domain:, inbox_url:)
+    end
+
+    Rails.logger.info "#{response.code}: #{response.body}"
+  rescue ActiveRecord::RecordInvalid => e
+    Rails.logger.error e.full_message
+  end
+end

--- a/app/models/pleroma_follow_handler.rb
+++ b/app/models/pleroma_follow_handler.rb
@@ -1,0 +1,64 @@
+class PleromaFollowHandler
+  def initialize(actor, json)
+    @actor = actor
+    @json = json
+  end
+
+  def call
+    inbox_url = @actor["inbox"]
+
+    response = send_accept_activity(inbox_url)
+
+    return unless response.code == "200"
+
+    Rails.logger.info "#{response.code}: #{response.body}"
+
+    response = send_follow_activity(inbox_url)
+
+    if response.code == "200"
+      domain = URI.parse(@actor["id"]).normalize.host
+      SubscribeServer.create!(domain:, inbox_url:)
+    end
+
+    Rails.logger.info "#{response.code}: #{response.body}"
+  rescue ActiveRecord::RecordInvalid => e
+    Rails.logger.error e.full_message
+  end
+
+  private
+
+  def send_accept_activity(inbox_url)
+    accept_activity = {
+      "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://w3id.org/security/v1"
+      ],
+      id: URI.join("https://#{ENV['LOCAL_DOMAIN']}/actor#accepts/follows/#{URI.parse(@actor['id']).normalize.host}"),
+      type: "Accept",
+      actor: "https://#{ENV['LOCAL_DOMAIN']}/actor",
+        object: {
+          id: @json["id"],
+          type: "Follow",
+          actor: @actor["id"],
+          object: "https://#{ENV['LOCAL_DOMAIN']}/actor"
+        }
+    }.to_json
+
+    ActivityPubDeliveryClient.new(inbox_url, accept_activity).send
+  end
+
+  def send_follow_activity(inbox_url)
+    follow_activity = {
+      "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://w3id.org/security/v1"
+      ],
+      id: "https://#{ENV['LOCAL_DOMAIN']}/actor#accepts/follows",
+      type: "Follow",
+      actor: "https://#{ENV['LOCAL_DOMAIN']}/actor",
+      object: @actor["id"]
+    }.to_json
+
+    ActivityPubDeliveryClient.new(inbox_url, follow_activity).send
+  end
+end

--- a/app/models/rebroadcast_handler.rb
+++ b/app/models/rebroadcast_handler.rb
@@ -2,7 +2,9 @@ class RebroadcastHandler
   def call(actor, json)
     domain = URI.parse(actor["id"]).normalize.host
 
-    activity_delivery_jobs = active_servers(domain).map { |_, inbox_url| ActivityPubDeliveryJob.new(inbox_url, json.to_json) }
+    activity_delivery_jobs = active_servers(domain).map do |_, inbox_url|
+      ActivityPubDeliveryJob.new(inbox_url, announce_json(json["object"]))
+    end
 
     ActiveJob.perform_all_later(activity_delivery_jobs)
 
@@ -15,5 +17,17 @@ class RebroadcastHandler
     records = SubscribeServer.pluck(:domain, :inbox_url)
     records.reject! { |record_domain, _| record_domain == domain }
     records
+  end
+
+  def announce_json(object)
+    {
+      "@context" => "https://www.w3.org/ns/activitystreams",
+      "id" => "https://#{ENV["LOCAL_DOMAIN"]}/actor##{SecureRandom.uuid}",
+      "type" => "Announce",
+      "actor" => "https://#{ENV["LOCAL_DOMAIN"]}/actor",
+      "object" => object,
+      "to" => [ "https://www.w3.org/ns/activitystreams#Public" ],
+      "published" => Time.now.utc.httpdate
+    }.to_json
   end
 end

--- a/app/models/server_follow_handler.rb
+++ b/app/models/server_follow_handler.rb
@@ -1,31 +1,9 @@
 class ServerFollowHandler
   def call(actor, json)
-    inbox_url = actor["endpoints"].is_a?(Hash) && actor["endpoints"]["sharedInbox"].present? ? actor["endpoints"]["sharedInbox"] : actor["inbox"]
-
-    domain = URI.parse(actor["id"]).normalize.host
-
-    SubscribeServer.create!(domain:, inbox_url:)
-
-    accept_activity = {
-      "@context": [
-        "https://www.w3.org/ns/activitystreams",
-        "https://w3id.org/security/v1"
-      ],
-      id: URI.join("https://#{ENV['LOCAL_DOMAIN']}/actor#accepts/follows/#{URI.parse(actor['id']).normalize.host}"),
-      type: "Accept",
-      actor: "https://#{ENV['LOCAL_DOMAIN']}/actor",
-        object: {
-          id: json["id"],
-          type: "Follow",
-          actor: actor["id"],
-          object: "https://#{ENV['LOCAL_DOMAIN']}/actor"
-        }
-    }.to_json
-
-    response = ActivityPubDeliveryClient.new(inbox_url, accept_activity).send
-
-    Rails.logger.info "#{response.code}: #{response.body}"
-  rescue ActiveRecord::RecordInvalid => e
-    Rails.logger.error e.full_message
+    if actor["preferredUsername"].present? && actor["preferredUsername"] == "relay"
+      PleromaFollowHandler.new(actor, json).call
+    else
+      MastodonFollowHandler.new(actor, json).call
+    end
   end
 end

--- a/app/views/root/index.html.erb
+++ b/app/views/root/index.html.erb
@@ -34,6 +34,15 @@
           </div>
         </div>
       </div>
+      <div>
+        <h2 class="text-3xl">PleromaとAkkoma の場合</h2>
+        <div class="flex flex-col gap-3">
+          <span class="text-2xl">以下のactor urlをメニューのCLIから追加してください。</span>
+          <div class="border-solid border-2 border-slate-950 p-4">
+            <%= "https://#{ENV["LOCAL_DOMAIN"]}/actor" %>
+          </div>
+        </div>
+      </div>
     </div>
   </div>
   <div class="flex flex-col gap-3">

--- a/docs/english/index.md
+++ b/docs/english/index.md
@@ -1,6 +1,7 @@
 # ActivityPub Relay
 
 Mastodon and Misskey(or other Misskey fork) supported ActivityPub Relay.
+Also support Pleroma and Akkoma.
 
 ## References
 

--- a/docs/japanese/index.md
+++ b/docs/japanese/index.md
@@ -1,6 +1,7 @@
 # ActivityPub Relay
 
 Mastodon と Misskey(またはMisskeyフォーク) に対応したActivityPubリレーサーバです。
+またPleromaとAkkomaにも対応しています。
 
 ## 参考実装
 

--- a/spec/models/activity_pub_type_handler_spec.rb
+++ b/spec/models/activity_pub_type_handler_spec.rb
@@ -3,10 +3,11 @@ require "rails_helper"
 RSpec.describe ActivityPubTypeHandler, type: :model do
   describe "#call" do
     context "when json type is Follow" do
+      let(:actor) { double(:actor) }
       let(:json) { { "type" => "Follow" } }
 
       it "should return :follow" do
-        result = ActivityPubTypeHandler.new(json).call
+        result = ActivityPubTypeHandler.new(actor, json).call
 
         expect(result).to eq :follow
       end
@@ -14,6 +15,7 @@ RSpec.describe ActivityPubTypeHandler, type: :model do
 
     context "when json type is Undo" do
       context "when json object type is Follow" do
+        let(:actor) { double(:actor) }
         let(:json) {
           {
             "type" => "Undo",
@@ -24,7 +26,7 @@ RSpec.describe ActivityPubTypeHandler, type: :model do
         }
 
         it "should return :unfollow" do
-          result = ActivityPubTypeHandler.new(json).call
+          result = ActivityPubTypeHandler.new(actor, json).call
 
           expect(result).to eq :unfollow
         end
@@ -35,6 +37,7 @@ RSpec.describe ActivityPubTypeHandler, type: :model do
       context "when signature is signed" do
         context "when ALLOWED_HASHTAGS is blank" do
           context "when to include public collection address" do
+            let(:actor) { double(:actor) }
             let(:json) {
               {
                 "type" => "Create",
@@ -45,13 +48,14 @@ RSpec.describe ActivityPubTypeHandler, type: :model do
             }
 
             it "should return :valid_for_rebroadcast" do
-              result = ActivityPubTypeHandler.new(json).call
+              result = ActivityPubTypeHandler.new(actor, json).call
 
               expect(result).to eq :valid_for_rebroadcast
             end
           end
 
           context "when cc include public collection address" do
+            let(:actor) { double(:actor) }
             let(:json) {
               {
                 "type" => "Create",
@@ -62,13 +66,14 @@ RSpec.describe ActivityPubTypeHandler, type: :model do
             }
 
             it "should return :valid_for_rebroadcast" do
-              result = ActivityPubTypeHandler.new(json).call
+              result = ActivityPubTypeHandler.new(actor, json).call
 
               expect(result).to eq :valid_for_rebroadcast
             end
           end
 
           context "when to and cc not include public collection address" do
+            let(:actor) { double(:actor) }
             let(:json) {
               {
                 "type" => "Create",
@@ -78,10 +83,36 @@ RSpec.describe ActivityPubTypeHandler, type: :model do
               }
             }
 
+            before do
+              allow(actor).to receive(:[]).with("preferredUsername").and_return("")
+            end
+
             it "should return :none" do
-              result = ActivityPubTypeHandler.new(json).call
+              result = ActivityPubTypeHandler.new(actor, json).call
 
               expect(result).to eq :none
+            end
+          end
+
+          context "when pleroma relay annouce" do
+            let(:actor) { double(:actor) }
+            let(:json) {
+              {
+                "type" => "Announce",
+                "signature" => "",
+                "to" => [ "https://www.example.com/followers" ],
+                "cc" => [ "https://www.example.com/followers" ]
+              }
+            }
+
+            before do
+              allow(actor).to receive(:[]).with("preferredUsername").and_return("relay")
+            end
+
+            it "should return :valid_for_rebroadcast" do
+              result = ActivityPubTypeHandler.new(actor, json).call
+
+              expect(result).to eq(:valid_for_rebroadcast)
             end
           end
         end
@@ -94,6 +125,7 @@ RSpec.describe ActivityPubTypeHandler, type: :model do
 
           context "when not include allowed hashtags" do
             context "when to include public collection address" do
+              let(:actor) { double(:actor) }
               let(:json) {
                 {
                   "type" => "Create",
@@ -117,14 +149,19 @@ RSpec.describe ActivityPubTypeHandler, type: :model do
                 }
               }
 
+              before do
+                allow(actor).to receive(:[]).with("preferredUsername").and_return("")
+              end
+
               it "should return :none" do
-                result = ActivityPubTypeHandler.new(json).call
+                result = ActivityPubTypeHandler.new(actor, json).call
 
                 expect(result).to eq :none
               end
             end
 
             context "when cc include public collection address" do
+              let(:actor) { double(:actor) }
               let(:json) {
                 {
                   "type" => "Create",
@@ -148,14 +185,19 @@ RSpec.describe ActivityPubTypeHandler, type: :model do
                 }
               }
 
+              before do
+                allow(actor).to receive(:[]).with("preferredUsername").and_return("")
+              end
+
               it "should return :none" do
-                result = ActivityPubTypeHandler.new(json).call
+                result = ActivityPubTypeHandler.new(actor, json).call
 
                 expect(result).to eq :none
               end
             end
 
             context "when to and cc not include public collection address" do
+              let(:actor) { double(:actor) }
               let(:json) {
                 {
                   "type" => "Create",
@@ -179,8 +221,12 @@ RSpec.describe ActivityPubTypeHandler, type: :model do
                 }
               }
 
+              before do
+                allow(actor).to receive(:[]).with("preferredUsername").and_return("")
+              end
+
               it "should return :none" do
-                result = ActivityPubTypeHandler.new(json).call
+                result = ActivityPubTypeHandler.new(actor, json).call
 
                 expect(result).to eq :none
               end
@@ -189,6 +235,7 @@ RSpec.describe ActivityPubTypeHandler, type: :model do
 
           context "when include allowed hashtags" do
             context "when to include public collection address" do
+              let(:actor) { double(:actor) }
               let(:json) {
                 {
                   "type" => "Create",
@@ -213,13 +260,14 @@ RSpec.describe ActivityPubTypeHandler, type: :model do
               }
 
               it "should return :valid_for_rebroadcast" do
-                result = ActivityPubTypeHandler.new(json).call
+                result = ActivityPubTypeHandler.new(actor, json).call
 
                 expect(result).to eq :valid_for_rebroadcast
               end
             end
 
             context "when cc include public collection address" do
+              let(:actor) { double(:actor) }
               let(:json) {
                 {
                   "type" => "Create",
@@ -244,13 +292,14 @@ RSpec.describe ActivityPubTypeHandler, type: :model do
               }
 
               it "should return :valid_for_rebroadcast" do
-                result = ActivityPubTypeHandler.new(json).call
+                result = ActivityPubTypeHandler.new(actor, json).call
 
                 expect(result).to eq :valid_for_rebroadcast
               end
             end
 
             context "when to and cc not include public collection address" do
+              let(:actor) { double(:actor) }
               let(:json) {
                 {
                   "type" => "Create",
@@ -274,8 +323,12 @@ RSpec.describe ActivityPubTypeHandler, type: :model do
                 }
               }
 
+              before do
+                allow(actor).to receive(:[]).with("preferredUsername").and_return("")
+              end
+
               it "should return :none" do
-                result = ActivityPubTypeHandler.new(json).call
+                result = ActivityPubTypeHandler.new(actor, json).call
 
                 expect(result).to eq :none
               end
@@ -285,6 +338,7 @@ RSpec.describe ActivityPubTypeHandler, type: :model do
       end
 
       context "when signature is not signed" do
+        let(:actor) { double(:actor) }
         let(:json) {
           {
             "type" => "Create",
@@ -292,8 +346,12 @@ RSpec.describe ActivityPubTypeHandler, type: :model do
           }
         }
 
+        before do
+          allow(actor).to receive(:[]).with("preferredUsername").and_return("")
+        end
+
         it "should return :none" do
-          result = ActivityPubTypeHandler.new(json).call
+          result = ActivityPubTypeHandler.new(actor, json).call
 
           expect(result).to eq :none
         end
@@ -301,6 +359,7 @@ RSpec.describe ActivityPubTypeHandler, type: :model do
     end
 
     context "when json type is not supported" do
+      let(:actor) { double(:actor) }
       let(:json) {
         {
           "type" => "Like",
@@ -309,8 +368,12 @@ RSpec.describe ActivityPubTypeHandler, type: :model do
         }
       }
 
+      before do
+        allow(actor).to receive(:[]).and_return("")
+      end
+
       it "should return :none" do
-        result = ActivityPubTypeHandler.new(json).call
+        result = ActivityPubTypeHandler.new(actor, json).call
 
         expect(result).to eq :none
       end

--- a/spec/models/inbox_process_handler_spec.rb
+++ b/spec/models/inbox_process_handler_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe InboxProcessHandler, type: :model do
     let(:json) { double(:json) }
 
     before do
-      allow(ActivityPubTypeHandler).to receive(:new).with(json).and_return(activity_pub_type_handler)
+      allow(ActivityPubTypeHandler).to receive(:new).with(actor, json).and_return(activity_pub_type_handler)
       allow(activity_pub_type_handler).to receive(:call).and_return(activity_pub_type)
     end
 

--- a/spec/models/mastodon_follow_handler_spec.rb
+++ b/spec/models/mastodon_follow_handler_spec.rb
@@ -1,0 +1,152 @@
+require "rails_helper"
+
+RSpec.describe MastodonFollowHandler, type: :model do
+  describe "#call" do
+    context "when actor['endpoints'] is hash" do
+      context "when actor['endpoints']['sharedInbox'] is present" do
+        let(:actor) { double(:actor) }
+        let(:json) { double(:json) }
+        let(:endpoints_hash) {
+          {
+            "sharedInbox" => "https://www.example.com/inbox"
+          }
+        }
+        let(:activity_pub_delivery_client) { instance_double(ActivityPubDeliveryClient) }
+        let(:response) { double(:response) }
+
+        before do
+          allow(actor).to receive(:[]).with("endpoints").and_return(endpoints_hash)
+          allow(actor).to receive(:[]).with("id").and_return("https://www.example.com")
+          allow(json).to receive(:[]).with("id").and_return("https://www.example.com/actor#accepts/follows/www.example.com")
+          allow(ActivityPubDeliveryClient).to receive(:new).and_return(activity_pub_delivery_client)
+          allow(activity_pub_delivery_client).to receive(:send).and_return(response)
+          allow(response).to receive(:code).and_return("202")
+          allow(response).to receive(:body).and_return("OK")
+        end
+
+        it "should call ActivityPubDeliveryClient#send" do
+          expect(activity_pub_delivery_client).to receive(:send)
+
+          MastodonFollowHandler.new(actor, json).call
+        end
+
+        it "should create SubscribeServer" do
+          expect {
+            MastodonFollowHandler.new(actor, json).call
+          }.to change { SubscribeServer.count }.from(0).to(1)
+        end
+
+        it "should loged" do
+          expect(Rails.logger).to receive(:info)
+
+          MastodonFollowHandler.new(actor, json).call
+        end
+      end
+
+      context "when actor['endpoints']['shared'] is blank" do
+        let(:actor) { double(:actor) }
+        let(:json) { double(:json) }
+        let(:endpoints_hash) {
+          {
+            "sharedInbox" => nil
+          }
+        }
+        let(:activity_pub_delivery_client) { instance_double(ActivityPubDeliveryClient) }
+        let(:response) { double(:response) }
+
+        before do
+          allow(actor).to receive(:[]).with("endpoints").and_return(endpoints_hash)
+          allow(actor).to receive(:[]).with("inbox").and_return("https://www.example.com/inbox")
+          allow(actor).to receive(:[]).with("id").and_return("https://www.example.com")
+          allow(json).to receive(:[]).with("id").and_return("https://www.example.com/actor#accepts/follows/www.example.com")
+          allow(ActivityPubDeliveryClient).to receive(:new).and_return(activity_pub_delivery_client)
+          allow(activity_pub_delivery_client).to receive(:send).and_return(response)
+          allow(response).to receive(:code).and_return("202")
+          allow(response).to receive(:body).and_return("OK")
+        end
+
+        it "should call ActivityPubDeliveryClient#send" do
+          expect(activity_pub_delivery_client).to receive(:send)
+
+          MastodonFollowHandler.new(actor, json).call
+        end
+
+        it "should create SubscribeServer" do
+          expect {
+            MastodonFollowHandler.new(actor, json).call
+          }.to change { SubscribeServer.count }.from(0).to(1)
+        end
+
+        it "should loged" do
+          expect(Rails.logger).to receive(:info)
+
+          MastodonFollowHandler.new(actor, json).call
+        end
+      end
+    end
+
+    context "when actor['endpoints'] is not hash" do
+      let(:actor) { double(:actor) }
+      let(:json) { double(:json) }
+      let(:activity_pub_delivery_client) { instance_double(ActivityPubDeliveryClient) }
+      let(:response) { double(:response) }
+
+      before do
+        allow(actor).to receive(:[]).with("endpoints").and_return(nil)
+        allow(actor).to receive(:[]).with("inbox").and_return("https://www.example.com/inbox")
+        allow(actor).to receive(:[]).with("id").and_return("https://www.example.com")
+        allow(json).to receive(:[]).with("id").and_return("https://www.example.com/actor#accepts/follows/www.example.com")
+        allow(ActivityPubDeliveryClient).to receive(:new).and_return(activity_pub_delivery_client)
+        allow(activity_pub_delivery_client).to receive(:send).and_return(response)
+        allow(response).to receive(:code).and_return("202")
+        allow(response).to receive(:body).and_return("OK")
+      end
+
+      it "should call ActivityPubDeliveryClient#send" do
+        expect(activity_pub_delivery_client).to receive(:send)
+
+        MastodonFollowHandler.new(actor, json).call
+      end
+
+      it "should create SubscribeServer" do
+        expect {
+          MastodonFollowHandler.new(actor, json).call
+        }.to change { SubscribeServer.count }.from(0).to(1)
+      end
+
+      it "should loged" do
+        expect(Rails.logger).to receive(:info)
+
+        MastodonFollowHandler.new(actor, json).call
+      end
+    end
+
+    context "when raise ActiveRecord::RecordInvalid" do
+      let(:actor) { double(:actor) }
+      let(:json) { double(:json) }
+      let(:activity_pub_delivery_client) { instance_double(ActivityPubDeliveryClient) }
+      let(:response) { double(:response) }
+
+      before do
+        allow(actor).to receive(:[]).with("endpoints").and_return(nil)
+        allow(actor).to receive(:[]).with("inbox").and_return("")
+        allow(actor).to receive(:[]).with("id").and_return("https://www.example.com")
+        allow(json).to receive(:[]).with("id").and_return("https://www.example.com/actor#accepts/follows/www.example.com")
+        allow(ActivityPubDeliveryClient).to receive(:new).and_return(activity_pub_delivery_client)
+        allow(activity_pub_delivery_client).to receive(:send).and_return(response)
+        allow(response).to receive(:code).and_return("202")
+        allow(response).to receive(:body).and_return("OK")
+      end
+
+      before do
+        create(:subscribe_server, domain: "www.example.com", inbox_url: "https://www.example.com/inbox")
+      end
+
+      it "shoud output error log" do
+        expect(Rails.logger).to receive(:error)
+
+        MastodonFollowHandler.new(actor, json).call
+      end
+    end
+  end
+end

--- a/spec/models/pleroma_follow_handler_spec.rb
+++ b/spec/models/pleroma_follow_handler_spec.rb
@@ -1,0 +1,98 @@
+require "rails_helper"
+
+RSpec.describe PleromaFollowHandler, type: :model do
+  describe "#call" do
+    let(:actor) { double(:actor) }
+    let(:json) { double(:json) }
+    let(:activity_pub_delivery_client) { instance_double(ActivityPubDeliveryClient) }
+
+    before do
+      allow(actor).to receive(:[]).with("inbox").and_return("https://www.example.com/inbox")
+      allow(actor).to receive(:[]).with("id").and_return("https://www.example.com/relay")
+      allow(json).to receive(:[]).with("id").and_return("https://www.example.com/actor#accepts/follows/www.example.com")
+      allow(ActivityPubDeliveryClient).to receive(:new).and_return(activity_pub_delivery_client)
+    end
+
+    context "when send accept activity response is not 200" do
+      let(:response) { double(:response) }
+      let(:code) { "500" }
+      let(:body) { "Internal Server Error" }
+
+      before do
+        allow(activity_pub_delivery_client).to receive(:send).and_return(response)
+        allow(response).to receive(:code).and_return(code)
+        allow(response).to receive(:body).and_return(body)
+      end
+
+      it "should return nil" do
+        result = PleromaFollowHandler.new(actor, json).call
+
+        expect(result).to be_nil
+      end
+
+      it "should not create SubscribeServer" do
+        expect {
+          PleromaFollowHandler.new(actor, json).call
+        }.not_to change { SubscribeServer.count }
+      end
+
+      it "should not loged" do
+        expect(Rails.logger).not_to receive(:info)
+
+        PleromaFollowHandler.new(actor, json).call
+      end
+    end
+
+    context "when send accept activity response is 200" do
+      context "when send follow activity response is not 200" do
+        let(:response) { Data.define(:code, :body) }
+
+        before do
+          count = 1
+
+          allow(activity_pub_delivery_client).to receive(:send).twice do
+            if count == 1
+              count += 1
+              response.new(code: "200", body: "OK")
+            else
+              response.new(code: "500", body: "Internal Server Error")
+            end
+          end
+        end
+
+        it "should not create SubscribeServer" do
+        end
+
+        it "should loged twice" do
+          expect(Rails.logger).to receive(:info).twice
+
+          PleromaFollowHandler.new(actor, json).call
+        end
+      end
+
+      context "when send follow activity response is 200" do
+        let(:response) { double(:response) }
+        let(:code) { "200" }
+        let(:body) { "OK" }
+
+        before do
+          allow(activity_pub_delivery_client).to receive(:send).and_return(response)
+          allow(response).to receive(:code).and_return(code)
+          allow(response).to receive(:body).and_return(body)
+        end
+
+        it "should create SubscribeServer" do
+          expect {
+            PleromaFollowHandler.new(actor, json).call
+          }.to change { SubscribeServer.count }.by(1)
+        end
+
+        it "should loged twice" do
+          expect(Rails.logger).to receive(:info).twice
+
+          PleromaFollowHandler.new(actor, json).call
+        end
+      end
+    end
+  end
+end

--- a/spec/models/server_follow_handler_spec.rb
+++ b/spec/models/server_follow_handler_spec.rb
@@ -2,103 +2,56 @@ require "rails_helper"
 
 RSpec.describe ServerFollowHandler, type: :model do
   describe "#call" do
-    context "when actor['endpoints'] is hash" do
-      context "when actor['endpoints']['sharedInbox'] is present" do
-        let(:actor) { double(:actor) }
-        let(:json) { double(:json) }
-        let(:endpoints_hash) {
-          {
-            "sharedInbox" => "https://www.example.com/inbox"
-          }
-        }
-        let(:activity_pub_delivery_client) { instance_double(ActivityPubDeliveryClient) }
-        let(:response) { double(:response) }
+    let(:actor) { double(:actor) }
+    let(:json) { double(:json) }
 
-        before do
-          allow(actor).to receive(:[]).with("endpoints").and_return(endpoints_hash)
-          allow(actor).to receive(:[]).with("id").and_return("https://www.example.com")
-          allow(json).to receive(:[]).with("id").and_return("https://www.example.com/actor#accepts/follows/www.example.com")
-          allow(ActivityPubDeliveryClient).to receive(:new).and_return(activity_pub_delivery_client)
-          allow(activity_pub_delivery_client).to receive(:send).and_return(response)
-          allow(response).to receive(:code).and_return(200)
-          allow(response).to receive(:body).and_return("OK")
-        end
-
-        it "should call ActivityPubDeliveryClient#send" do
-          expect(activity_pub_delivery_client).to receive(:send)
-
-          ServerFollowHandler.new.call(actor, json)
-        end
-      end
-
-      context "when actor['endpoints']['shared'] is blank" do
-        let(:actor) { double(:actor) }
-        let(:json) { double(:json) }
-        let(:endpoints_hash) {
-          {
-            "sharedInbox" => nil
-          }
-        }
-        let(:activity_pub_delivery_client) { instance_double(ActivityPubDeliveryClient) }
-        let(:response) { double(:response) }
-
-        before do
-          allow(actor).to receive(:[]).with("endpoints").and_return(endpoints_hash)
-          allow(actor).to receive(:[]).with("inbox").and_return("https://www.example.com/inbox")
-          allow(actor).to receive(:[]).with("id").and_return("https://www.example.com")
-          allow(json).to receive(:[]).with("id").and_return("https://www.example.com/actor#accepts/follows/www.example.com")
-          allow(ActivityPubDeliveryClient).to receive(:new).and_return(activity_pub_delivery_client)
-          allow(activity_pub_delivery_client).to receive(:send).and_return(response)
-          allow(response).to receive(:code).and_return(200)
-          allow(response).to receive(:body).and_return("OK")
-        end
-
-        it "should call ActivityPubDeliveryClient#send" do
-          expect(activity_pub_delivery_client).to receive(:send)
-
-          ServerFollowHandler.new.call(actor, json)
-        end
-      end
-    end
-
-    context "when actor['endpoints'] is not hash" do
-      let(:actor) { double(:actor) }
-      let(:json) { double(:json) }
-      let(:activity_pub_delivery_client) { instance_double(ActivityPubDeliveryClient) }
-      let(:response) { double(:response) }
+    context "actor['preferredUsername'] is blank" do
+      let(:mastodon_follow_handler) { instance_double(MastodonFollowHandler) }
 
       before do
-        allow(actor).to receive(:[]).with("endpoints").and_return(nil)
-        allow(actor).to receive(:[]).with("inbox").and_return("https://www.example.com/inbox")
-        allow(actor).to receive(:[]).with("id").and_return("https://www.example.com")
-        allow(json).to receive(:[]).with("id").and_return("https://www.example.com/actor#accepts/follows/www.example.com")
-        allow(ActivityPubDeliveryClient).to receive(:new).and_return(activity_pub_delivery_client)
-        allow(activity_pub_delivery_client).to receive(:send).and_return(response)
-        allow(response).to receive(:code).and_return(200)
-        allow(response).to receive(:body).and_return("OK")
+        allow(actor).to receive(:[]).with("preferredUsername").and_return("")
+        allow(MastodonFollowHandler).to receive(:new).with(actor, json).and_return(mastodon_follow_handler)
+        allow(mastodon_follow_handler).to receive(:call)
       end
 
-      it "should call ActivityPubDeliveryClient#send" do
-        expect(activity_pub_delivery_client).to receive(:send)
+      it "should call MastodonFollowHandler#call" do
+        expect(mastodon_follow_handler).to receive(:call)
 
         ServerFollowHandler.new.call(actor, json)
       end
     end
 
-    context "when raise ActiveRecord::RecordInvalid" do
-      let(:actor) { double(:actor) }
-      let(:json) { double(:json) }
+    context "actor['preferredUsername'] is present" do
+      context "actor['preferredUsername'] is not 'relay'" do
+        let(:mastodon_follow_handler) { instance_double(MastodonFollowHandler) }
 
-      before do
-        allow(actor).to receive(:[]).with("endpoints").and_return(nil)
-        allow(actor).to receive(:[]).with("inbox").and_return("")
-        allow(actor).to receive(:[]).with("id").and_return("https://www.example.com")
+        before do
+          allow(actor).to receive(:[]).with("preferredUsername").and_return("mastodon")
+          allow(MastodonFollowHandler).to receive(:new).with(actor, json).and_return(mastodon_follow_handler)
+          allow(mastodon_follow_handler).to receive(:call)
+        end
+
+        it "should call MastodonFollowHandler#call" do
+          expect(mastodon_follow_handler).to receive(:call)
+
+          ServerFollowHandler.new.call(actor, json)
+        end
       end
 
-      it "shoud output error log" do
-        expect(Rails.logger).to receive(:error)
+      context "actor['preferredUsername'] is 'relay'" do
+        let(:pleroma_follow_handler) { instance_double(PleromaFollowHandler) }
 
-        ServerFollowHandler.new.call(actor, json)
+        before do
+          allow(actor).to receive(:[]).with("preferredUsername").and_return("relay")
+          allow(PleromaFollowHandler).to receive(:new).with(actor, json).and_return(pleroma_follow_handler)
+          allow(pleroma_follow_handler).to receive(:call)
+        end
+
+        it "should call PleromaFollowHandler#call" do
+          expect(pleroma_follow_handler).to receive(:call)
+
+          ServerFollowHandler.new.call(actor, json)
+        end
       end
     end
   end

--- a/spec/requests/actors_controller_spec.rb
+++ b/spec/requests/actors_controller_spec.rb
@@ -29,6 +29,7 @@ RSpec.describe "/actors", type: :request do
         "type" => "Service",
         "preferredUsername" => "relay",
         "inbox" => "https://www.example.com/inbox",
+        "url" => "https://www.example.com/actor",
         "publicKey" => {
           "id" => "https://www.example.com/actor#main-key",
           "owner"=>"https://www.example.com/actor",


### PR DESCRIPTION
## Motivation or Background

Fix inplimentation for Pleroma and Akkoma relay flow.

## Detail

Fix Pleroma and Akkoma server's following ActivityPub Relay.
And rebroadcast with Announce type for Pleroma and Akkoma.
Also Mastodon and Misskey rebroadcast type changed to Announce.

Added document to support Pleroma and Akkoma relay.

## Checklist
- [x] Passed Test
- [x] Migration Rollback
- [x] Need to write this change in relase notes?

## Context

Fix Pleroma and Akkoma relay support