### PR TITLE
Re:Fix Pleroma and Akkoma relay follow

### DIFF
--- a/app/models/activity_pub_delivery_client.rb
+++ b/app/models/activity_pub_delivery_client.rb
@@ -56,6 +56,6 @@ class ActivityPubDeliveryClient
   end
 
   def header
-    "keyId=\"#{actor_url}\",algorithm=\"rsa-sha256\",headers=\"(request-target) host date digest\",signature=\"#{signature}\""
+    "keyId=\"#{actor_url}#main-key\",algorithm=\"rsa-sha256\",headers=\"(request-target) host date digest\",signature=\"#{signature}\""
   end
 end

--- a/app/models/pleroma_follow_handler.rb
+++ b/app/models/pleroma_follow_handler.rb
@@ -9,18 +9,18 @@ class PleromaFollowHandler
 
     response = send_accept_activity(inbox_url)
 
-    return unless response.code == "200"
-
     Rails.logger.info "#{response.code}: #{response.body}"
 
+    return unless response.code == "200"
+
     response = send_follow_activity(inbox_url)
+
+    Rails.logger.info "#{response.code}: #{response.body}"
 
     if response.code == "200"
       domain = URI.parse(@actor["id"]).normalize.host
       SubscribeServer.create!(domain:, inbox_url:)
     end
-
-    Rails.logger.info "#{response.code}: #{response.body}"
   rescue ActiveRecord::RecordInvalid => e
     Rails.logger.error e.full_message
   end

--- a/spec/models/activity_pub_delivery_client_spec.rb
+++ b/spec/models/activity_pub_delivery_client_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe ActivityPubDeliveryClient, type: :model do
         'Host': "www.example.com",
         'Date': Time.now.utc.httpdate,
         'Digest': "SHA-256=UEf3Gb+7KoVuTocInGSJWg3IbPqbinwd7EYfbFFiZKQ=",
-        'Signature': "keyId=\"https://www.example.com/actor\",algorithm=\"rsa-sha256\",headers=\"(request-target) host date digest\",signature=\"#{signature}\"",
+        'Signature': "keyId=\"https://www.example.com/actor#main-key\",algorithm=\"rsa-sha256\",headers=\"(request-target) host date digest\",signature=\"#{signature}\"",
         'User-Agent': "activity-pub-relay",
         'Content-Type': "application/ld+json;profile=\"https://www.w3.org/ns/activitystreams\""
       }

--- a/spec/models/pleroma_follow_handler_spec.rb
+++ b/spec/models/pleroma_follow_handler_spec.rb
@@ -36,8 +36,8 @@ RSpec.describe PleromaFollowHandler, type: :model do
         }.not_to change { SubscribeServer.count }
       end
 
-      it "should not loged" do
-        expect(Rails.logger).not_to receive(:info)
+      it "should loged" do
+        expect(Rails.logger).to receive(:info)
 
         PleromaFollowHandler.new(actor, json).call
       end


### PR DESCRIPTION


## Motivation or Background

Follow up #98 

## Detail

Pleroma and Akkoma need /actor#main-key, but ActivityPub Relay was send /actor.
So, Pleroma and Akkoma relay subscribe failed with unmatched signing_keys.

## Checklist
- [x] Passed Test
- [x] Migration Rollback
- [ ] Need to write this change in relase notes?

## Context

For Pleroma and Akkoma support.
