### PR TITLE
Fix Hashtag Relay option to deploy environment variable not set.

### DIFF
--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -64,6 +64,9 @@ env:
     SOURCE_CODE_LINK: <%= ENV["SOURCE_CODE_LINK"] %>
     ADMIN_LINKS: <%= ENV["ADMIN_LINKS"] %>
 
+    # Use Hashtag Relay Option
+    ALLOWED_HASHTAGS: <%= ENV["ALLOWED_HASHTAGS"] %>
+
 # Aliases are triggered with "bin/kamal <alias>". You can overwrite arguments on invocation:
 # "bin/kamal logs -r job" will tail logs from the first server in the job section.
 aliases:


### PR DESCRIPTION
## Motivation or Background

Fix Hashtag relay Option to deploy.

## Detail

Ditto

## Checklist
- [x] Passed Test
- [x] Migration Rollback
- [x] Need to write this change in relase notes?

## Context

None.
