### PR TITLE
Introduce Delivery Suspend

### DIFF
--- a/app/controllers/dashboard/subscribe_servers_controller.rb
+++ b/app/controllers/dashboard/subscribe_servers_controller.rb
@@ -47,6 +47,6 @@ class Dashboard::SubscribeServersController < ApplicationController
 
     # Only allow a list of trusted parameters through.
     def subscribe_server_params
-      params.expect(subscribe_server: [ :domain, :inbox_url ])
+      params.expect(subscribe_server: [ :domain, :inbox_url, :delivery_suspend ])
     end
 end

--- a/app/models/rebroadcast_handler.rb
+++ b/app/models/rebroadcast_handler.rb
@@ -6,6 +6,8 @@ class RebroadcastHandler
       ActivityPubDeliveryJob.new(inbox_url, announce_json(json["object"]))
     end
 
+    return if activity_delivery_jobs.empty?
+
     ActiveJob.perform_all_later(activity_delivery_jobs)
 
     RebroadcastCounter.increment
@@ -14,8 +16,8 @@ class RebroadcastHandler
   private
 
   def active_servers(domain)
-    records = SubscribeServer.pluck(:domain, :inbox_url)
-    records.reject! { |record_domain, _| record_domain == domain }
+    records = SubscribeServer.pluck(:domain, :inbox_url, :delivery_suspend)
+    records.reject! { |record_domain, _, delivery_suspend| record_domain == domain || delivery_suspend }
     records
   end
 

--- a/app/views/dashboard/subscribe_servers/_form.html.erb
+++ b/app/views/dashboard/subscribe_servers/_form.html.erb
@@ -21,6 +21,10 @@
     <%= form.text_field :inbox_url, readonly: true %>
   </div>
 
+  <div class="flex flex-col gap-2">
+    <%= form.label :delivery_suspend %>
+    <%= form.checkbox :delivery_suspend %>
+  </div>
 
   <div>
     <%= form.submit "Update", class: "border-solid border-2 border-slate-950 bg-cyan-400 text-white p-3" %>

--- a/db/migrate/20241225032244_add_delivery_suspend_column_to_subscribe_servers.rb
+++ b/db/migrate/20241225032244_add_delivery_suspend_column_to_subscribe_servers.rb
@@ -1,0 +1,5 @@
+class AddDeliverySuspendColumnToSubscribeServers < ActiveRecord::Migration[8.0]
+  def change
+    add_column :subscribe_servers, :delivery_suspend, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2024_12_02_135932) do
+ActiveRecord::Schema[8.0].define(version: 2024_12_25_032244) do
   create_table "account_login_change_keys", force: :cascade do |t|
     t.string "key", null: false
     t.string "login", null: false
@@ -44,7 +44,7 @@ ActiveRecord::Schema[8.0].define(version: 2024_12_02_135932) do
     t.integer "status", default: 1, null: false
     t.string "email", null: false
     t.string "password_hash"
-    t.index ["email"], name: "index_accounts_on_email", unique: true, where: "status IN (1, 2) /*application='ActivityPubRelay'*/ /*application='ActivityPubRelay'*/ /*application='ActivityPubRelay'*/ /*application='ActivityPubRelay'*/"
+    t.index ["email"], name: "index_accounts_on_email", unique: true, where: "status IN (1, 2)"
   end
 
   create_table "subscribe_servers", force: :cascade do |t|
@@ -52,6 +52,7 @@ ActiveRecord::Schema[8.0].define(version: 2024_12_02_135932) do
     t.string "inbox_url", default: "", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "delivery_suspend", default: false, null: false
     t.index ["domain"], name: "index_subscribe_servers_on_domain", unique: true
   end
 

--- a/spec/factories/subscribe_servers.rb
+++ b/spec/factories/subscribe_servers.rb
@@ -2,5 +2,6 @@ FactoryBot.define do
   factory :subscribe_server do
     domain { "www.example.com" }
     inbox_url { "https://www.example.com/inbox" }
+    delivery_suspend { false }
   end
 end

--- a/spec/models/rebroadcast_handler_spec.rb
+++ b/spec/models/rebroadcast_handler_spec.rb
@@ -6,30 +6,75 @@ RSpec.describe RebroadcastHandler, type: :model do
     let(:json) { double(:json) }
     let(:cache_key) { Time.current.strftime("%Y-%m-%d") }
 
-    before do
-      allow(actor).to receive(:[]).with("id").and_return("https://www.example.com")
+    context "when delivery_suspend subscribe_server not exist" do
+      before do
+        allow(actor).to receive(:[]).with("id").and_return("https://www.example.com")
+        allow(json).to receive(:[]).with("object").and_return("")
+        create(:subscribe_server, domain: "example.com", inbox_url: "https://example.com/inbox", delivery_suspend: false)
+      end
+
+      after do
+        Rails.cache.delete(cache_key)
+      end
+
+      it "should call ActiveJob.perform_all_later" do
+        expect(ActiveJob).to receive(:perform_all_later)
+
+        RebroadcastHandler.new.call(actor, json)
+      end
+
+      it "should call RebroadcastCounter.increment" do
+        expect(RebroadcastCounter).to receive(:increment)
+
+        RebroadcastHandler.new.call(actor, json)
+      end
+
+      it "should create rebroadcast counter cache" do
+        RebroadcastHandler.new.call(actor, json)
+
+        expect(Rails.cache.read(cache_key)).to eq 1
+      end
+
+      it "should enqueue job" do
+        RebroadcastHandler.new.call(actor, json)
+
+        expect(SolidQueue::Job.count).to eq 1
+      end
     end
 
-    after do
-      Rails.cache.delete(cache_key)
-    end
+    context "when delivery_suspend subscribe_server exist" do
+      before do
+        allow(actor).to receive(:[]).with("id").and_return("https://www.example.com")
+        create(:subscribe_server, domain: "example.com", inbox_url: "https://example.com/inbox", delivery_suspend: true)
+      end
 
-    it "should call ActiveJob.perform_all_later" do
-      expect(ActiveJob).to receive(:perform_all_later)
+      after do
+        Rails.cache.delete(cache_key)
+      end
 
-      RebroadcastHandler.new.call(actor, json)
-    end
+      it "should call ActiveJob.perform_all_later" do
+        expect(ActiveJob).not_to receive(:perform_all_later)
 
-    it "should call RebroadcastCounter.increment" do
-      expect(RebroadcastCounter).to receive(:increment)
+        RebroadcastHandler.new.call(actor, json)
+      end
 
-      RebroadcastHandler.new.call(actor, json)
-    end
+      it "should not call RebroadcastCounter.increment" do
+        expect(RebroadcastCounter).not_to receive(:increment)
 
-    it "should create rebroadcast counter cache" do
-      RebroadcastHandler.new.call(actor, json)
+        RebroadcastHandler.new.call(actor, json)
+      end
 
-      expect(Rails.cache.read(cache_key)).to eq 1
+      it "should not create rebroadcast counter cache" do
+        RebroadcastHandler.new.call(actor, json)
+
+        expect(Rails.cache.read(cache_key)).to eq nil
+      end
+
+      it "should not enqueue job" do
+        RebroadcastHandler.new.call(actor, json)
+
+        expect(SolidQueue::Job.count).to eq 0
+      end
     end
   end
 end

--- a/spec/requests/dashboard/subscribe_servers_controller_spec.rb
+++ b/spec/requests/dashboard/subscribe_servers_controller_spec.rb
@@ -135,7 +135,8 @@ RSpec.describe "/dashboard/subscribe_servers", type: :request do
             put "/dashboard/subscribe_servers/#{subscribe_server.id}", params: {
               subscribe_server: {
                 domain: "",
-                inbox_url: "https://www.example.com/inbox"
+                inbox_url: "https://www.example.com/inbox",
+                delivery_suspend: false
               }
             }
           end
@@ -150,7 +151,8 @@ RSpec.describe "/dashboard/subscribe_servers", type: :request do
             put "/dashboard/subscribe_servers/#{subscribe_server.id}", params: {
               subscribe_server: {
                 domain: "www.example.com",
-                inbox_url: ""
+                inbox_url: "",
+                delivery_suspend: false
               }
             }
           end
@@ -160,12 +162,13 @@ RSpec.describe "/dashboard/subscribe_servers", type: :request do
           end
         end
 
-        context "when domain and inbox_url are present" do
+        context "when domain and inbox_url are present. also correct delivery_suspend is set" do
           before do
             put "/dashboard/subscribe_servers/#{subscribe_server.id}", params: {
               subscribe_server: {
                 domain: "www.example.com",
-                inbox_url: "https://www.example.com/inbox"
+                inbox_url: "https://www.example.com/inbox",
+                delivery_suspend: true
               }
             }
           end


### PR DESCRIPTION
## Motivation or Background

Sometimes join server was down to some reason.
And, ActivityPub Relay queue is clogged.

So, this change introduce delivery temporarily suspended.

## Detail

Add delivery_suspend column to subscribe_servers table.
And admini can suspend activity delivery from dashboard.

## Checklist
- [x] Passed Test
- [x] Migration Rollback
- [x] Need to write this change in relase notes?

## Context

None.
