### PR TITLE
Introduce Domain Block

### DIFF
--- a/app/views/dashboard/subscribe_servers/_form.html.erb
+++ b/app/views/dashboard/subscribe_servers/_form.html.erb
@@ -26,6 +26,11 @@
     <%= form.checkbox :delivery_suspend %>
   </div>
 
+  <div class="flex flex-col gap-2">
+    <%= form.label :domain_block %>
+    <%= form.checkbox :domain_block %>
+  </div>
+
   <div>
     <%= form.submit "Update", class: "border-solid border-2 border-slate-950 bg-cyan-400 text-white p-3" %>
   </div>

--- a/app/views/dashboard/subscribe_servers/_subscribe_server.html.erb
+++ b/app/views/dashboard/subscribe_servers/_subscribe_server.html.erb
@@ -12,4 +12,18 @@
       <%= subscribe_server.inbox_url %>
     </p>
   </div>
+
+  <div>
+    <h3>Delivery Suspend</h3>
+    <p class="underline">
+      <%= subscribe_server.delivery_suspend %>
+    </p>
+  </div>
+
+  <div>
+    <h3>Domain Block</h3>
+    <p class="underline">
+      <%= subscribe_server.domain_block %>
+    </p>
+  </div>
 </div>

--- a/db/migrate/20241226041309_add_block_column_to_subscribe_servers.rb
+++ b/db/migrate/20241226041309_add_block_column_to_subscribe_servers.rb
@@ -1,0 +1,5 @@
+class AddBlockColumnToSubscribeServers < ActiveRecord::Migration[8.0]
+  def change
+    add_column :subscribe_servers, :domain_block, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2024_12_25_032244) do
+ActiveRecord::Schema[8.0].define(version: 2024_12_26_041309) do
   create_table "account_login_change_keys", force: :cascade do |t|
     t.string "key", null: false
     t.string "login", null: false
@@ -53,6 +53,7 @@ ActiveRecord::Schema[8.0].define(version: 2024_12_25_032244) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "delivery_suspend", default: false, null: false
+    t.boolean "domain_block", default: false, null: false
     t.index ["domain"], name: "index_subscribe_servers_on_domain", unique: true
   end
 

--- a/spec/factories/subscribe_servers.rb
+++ b/spec/factories/subscribe_servers.rb
@@ -3,5 +3,6 @@ FactoryBot.define do
     domain { "www.example.com" }
     inbox_url { "https://www.example.com/inbox" }
     delivery_suspend { false }
+    domain_block { false }
   end
 end

--- a/spec/requests/inboxes_controller_spec.rb
+++ b/spec/requests/inboxes_controller_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe "/inbox", type: :request do
     context "account is no present" do
       before do
         account = double(:account)
+        allow(account).to receive(:[]).with("id").and_return("https://www.example.com/S_H_")
         allow_any_instance_of(SignatureVerificater).to receive(:call).and_return(account)
         allow(account).to receive(:present?).and_return(false)
       end
@@ -21,6 +22,7 @@ RSpec.describe "/inbox", type: :request do
       let(:body) { "body" }
 
       before do
+        allow(account).to receive(:[]).with("id").and_return("https://www.example.com/S_H_")
         allow(Oj).to receive(:load).and_return(body)
         allow_any_instance_of(SignatureVerificater).to receive(:call).and_return(account)
         allow(account).to receive(:present?).and_return(true)
@@ -34,6 +36,31 @@ RSpec.describe "/inbox", type: :request do
 
       it "should enqueued InboxProcessJob" do
         expect(InboxProcessJob).to receive(:perform_later)
+
+        post "/inbox"
+      end
+    end
+
+    context "when domain is blocked" do
+      let(:account) { "account" }
+      let(:body) { "body" }
+
+      before do
+        create(:subscribe_server, domain: "www.example.com", domain_block: true)
+        allow(account).to receive(:[]).with("id").and_return("https://www.example.com/S_H_")
+        allow(Oj).to receive(:load).and_return(body)
+        allow_any_instance_of(SignatureVerificater).to receive(:call).and_return(account)
+        allow(account).to receive(:present?).and_return(true)
+      end
+
+      it "should return 401" do
+        post "/inbox"
+
+        expect(response.status).to eq 401
+      end
+
+      it "should not enqueued InboxProcessJob" do
+        expect(InboxProcessJob).not_to receive(:perform_later)
 
         post "/inbox"
       end


### PR DESCRIPTION
## Motivation or Background


Introduce domain block.
Somtimes relay server admin want domain block to server that spam account exist.
But, ActivityPub Relay was not provided domain block feature.
So, this change introduce this feature.

## Detail

Add domain_block column to subscribe_servers table.
And, using domain_block in /inbox endpoint to block activity.
Also, not rebroadcast activity to domain blocked server.

## Checklist
- [x] Passed Test
- [x] Migration Rollback
- [x] Need to write this change in relase notes?

## Context

None.