### PR TITLE
Add libyaml-dev dependency for build ActivityPub Relay

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ FROM base AS build
 
 # Install packages needed to build gems
 RUN apt-get update -qq && \
-    apt-get install --no-install-recommends -y build-essential git pkg-config && \
+    apt-get install --no-install-recommends -y build-essential libyaml-dev git pkg-config && \
     rm -rf /var/lib/apt/lists /var/cache/apt/archives
 
 # Install application gems


### PR DESCRIPTION
## Motivation or Background

Add libyaml-dev dependency for build to ActivityPub Relay.

## Detail

ruby:3.3.6-slim image removed libyaml-dev in https://github.com/docker-library/ruby/pull/493


## Checklist
- [x] Passed Test
- [ ] Migration Rollback
- [ ] Need to write this change in relase notes?

## Context

None
