### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   scan_ruby:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/S-H-GAMELINKS/activity-pub-relay/security/code-scanning/5](https://github.com/S-H-GAMELINKS/activity-pub-relay/security/code-scanning/5)

To fix the issue, add an explicit `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Since the workflow primarily involves scanning, linting, testing, and reporting, it likely only requires `contents: read` permissions. This block can be added at the root level of the workflow to apply to all jobs or to individual jobs if different permissions are needed for each.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
